### PR TITLE
Make symbols invisible where necessary

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,12 +15,19 @@ libpolycap_la_SOURCES = \
 	$(NULL)
 libpolycap_la_CPPFLAGS = @easyRNG_CFLAGS@ @gsl_CFLAGS@ @xraylib_CFLAGS@ -I$(top_srcdir)/include @HDF5_CFLAGS@
 libpolycap_la_LIBADD = @easyRNG_LIBS@ @gsl_LIBS@ @xraylib_LIBS@ @HDF5_LIBS@ -lm
-libpolycap_la_CFLAGS = @OPENMP_CFLAGS@
+libpolycap_la_CFLAGS = @OPENMP_CFLAGS@ -Wno-error=attributes
 libpolycap_la_LDFLAGS = @OPENMP_CFLAGS@ @LDFLAGS_LIBPOLYCAP@
+
+check_LTLIBRARIES = libpolycap-check.la
+libpolycap_check_la_SOURCES = $(libpolycap_la_SOURCES)
+libpolycap_check_la_CPPFLAGS = $(libpolycap_la_CPPFLAGS) -DTEST_BUILD
+libpolycap_check_la_LIBADD = $(libpolycap_la_LIBADD)
+libpolycap_check_la_CFLAGS = $(libpolycap_la_CFLAGS)
+libpolycap_check_la_LDFLAGS = $(libpolycap_la_LDFLAGS)
 
 bin_PROGRAMS = polycap
 polycap_SOURCES = main.c 
-polycap_CFLAGS = @OPENMP_CFLAGS@
+polycap_CFLAGS = @OPENMP_CFLAGS@ -Wno-error=attributes
 polycap_CPPFLAGS = @easyRNG_CFLAGS@ @gsl_CFLAGS@ -I$(srcdir) -I$(top_srcdir)/include
 polycap_LDADD = libpolycap.la
 polycap_LDFLAGS = @OPENMP_CFLAGS@

--- a/src/polycap-capil.c
+++ b/src/polycap-capil.c
@@ -11,7 +11,7 @@
 
 //===========================================
 // calculates the intersection point coordinates of the photon trajectory and a given linear segment of the capillary wall
-int polycap_capil_segment(polycap_vector3 cap_coord0, polycap_vector3 cap_coord1, double cap_rad0, double cap_rad1, polycap_vector3 *photon_coord, polycap_vector3 photon_dir, polycap_vector3 *surface_norm, double *alfa, polycap_error **error)
+STATIC int polycap_capil_segment(polycap_vector3 cap_coord0, polycap_vector3 cap_coord1, double cap_rad0, double cap_rad1, polycap_vector3 *photon_coord, polycap_vector3 photon_dir, polycap_vector3 *surface_norm, double *alfa, polycap_error **error)
 {
 	double disc, solution1, solution2, sol_final; //discriminant and solutions of formed quadratic equation
 	polycap_vector3 photon_coord_rel, cap_coord1_rel; //coordinates of previous photon interaction and current point capillary axis, with previous point capillary axis set as origin [0,0,0]
@@ -151,7 +151,7 @@ int polycap_capil_segment(polycap_vector3 cap_coord0, polycap_vector3 cap_coord1
 }
 
 //===========================================
-double polycap_refl(double e, double theta, double density, double scatf, double lin_abs_coeff, polycap_error **error){
+STATIC double polycap_refl(double e, double theta, double density, double scatf, double lin_abs_coeff, polycap_error **error) {
 	// scatf = SUM( (weight/A) * (Z + f')) over all elements in capillary material
 	double complex alfa, beta; //alfa and beta component for Fresnel equation delta term (delta = alfa - i*beta)
 	double complex rtot; //reflectivity
@@ -189,7 +189,7 @@ double polycap_refl(double e, double theta, double density, double scatf, double
 }
 
 //===========================================
-int polycap_capil_reflect(polycap_photon *photon, double alfa, polycap_error **error)
+STATIC int polycap_capil_reflect(polycap_photon *photon, double alfa, polycap_error **error)
 {
 	int i, iesc=0;
 	double d_esc;  //distance in capillary at which photon escaped divided by propagation vector in z direction
@@ -247,7 +247,7 @@ int polycap_capil_reflect(polycap_photon *photon, double alfa, polycap_error **e
 
 //===========================================
 // trace photon through capillary
-int polycap_capil_trace(int *ix, polycap_photon *photon, polycap_description *description, double *cap_x, double *cap_y, polycap_error **error)
+HIDDEN int polycap_capil_trace(int *ix, polycap_photon *photon, polycap_description *description, double *cap_x, double *cap_y, polycap_error **error)
 {
 	int i, iesc=0;
 	double cap_rad0, cap_rad1;

--- a/src/polycap-description.c
+++ b/src/polycap-description.c
@@ -13,7 +13,7 @@
 #include <errno.h>
 
 //===========================================
-char *polycap_read_input_line(FILE *fptr, polycap_error **error)
+HIDDEN char *polycap_read_input_line(FILE *fptr, polycap_error **error)
 {
 	char *strPtr;
 	unsigned int j = 0;
@@ -47,7 +47,7 @@ char *polycap_read_input_line(FILE *fptr, polycap_error **error)
 	return realloc(strPtr, sizeof(char)*j);
 }
 //===========================================
-void polycap_description_check_weight(size_t nelem, double wi[], polycap_error **error)
+HIDDEN void polycap_description_check_weight(size_t nelem, double wi[], polycap_error **error)
 {
 	int i;
 	double sum = 0;

--- a/src/polycap-photon.c
+++ b/src/polycap-photon.c
@@ -11,7 +11,7 @@
 #include <xraylib.h>
 
 //===========================================
-void polycap_photon_scatf(polycap_photon *photon, polycap_error **error)
+HIDDEN void polycap_photon_scatf(polycap_photon *photon, polycap_error **error)
 {
 	int i, j;
 	double totmu, scatf;
@@ -161,7 +161,7 @@ polycap_photon* polycap_photon_new(polycap_description *description, polycap_rng
 }
 
 //===========================================
-int polycap_photon_within_pc_boundary(double polycap_radius, polycap_vector3 photon_coord, polycap_error **error)
+HIDDEN int polycap_photon_within_pc_boundary(double polycap_radius, polycap_vector3 photon_coord, polycap_error **error)
 {
 	double hex_edge_norm1[2], hex_edge_norm2[2], hex_edge_norm3[3]; //normal vectors of edges of the hexagonal polycap shape
 	double d_cen2hexedge; //distance between polycap centre and edges (along edge norm)
@@ -194,7 +194,7 @@ int polycap_photon_within_pc_boundary(double polycap_radius, polycap_vector3 pho
 }
 
 //===========================================
-void polycap_norm(polycap_vector3 *vect)
+HIDDEN void polycap_norm(polycap_vector3 *vect)
 {
 	double sum = 0;
 
@@ -208,7 +208,7 @@ void polycap_norm(polycap_vector3 *vect)
 }
 
 //===========================================
-double polycap_scalar(polycap_vector3 vect1, polycap_vector3 vect2)
+HIDDEN double polycap_scalar(polycap_vector3 vect1, polycap_vector3 vect2)
 {
 	double sum = 0;
 

--- a/src/polycap-private.h
+++ b/src/polycap-private.h
@@ -13,6 +13,18 @@
 #define DELTA 1.e-10
 #define BINSIZE 20.e-4 /* cm */
 
+#ifdef TEST_BUILD
+  #define STATIC 
+  #define HIDDEN
+  // additional prototypes for the tests
+  int polycap_capil_segment(polycap_vector3 cap_coord0, polycap_vector3 cap_coord1, double cap_rad0, double cap_rad1, polycap_vector3 *photon_coord, polycap_vector3 photon_dir, polycap_vector3 *surface_norm, double *alfa, polycap_error **error);
+  double polycap_refl(double e, double theta, double density, double scatf, double lin_abs_coeff, polycap_error **error);
+  int polycap_capil_reflect(polycap_photon *photon, double alfa, polycap_error **error);
+#else
+  #define STATIC static
+  #define HIDDEN __attribute__((visibility("hidden")))
+#endif
+
 #ifdef HAVE_EASYRNG
   #include <easy_rng.h>
   #include <easy_randist.h>
@@ -129,9 +141,6 @@ double polycap_scalar(polycap_vector3 vect1, polycap_vector3 vect2);
 int polycap_capil_trace(int *ix, polycap_photon *photon, polycap_description *description, double *cap_x, double *cap_y, polycap_error **error);
 char *polycap_read_input_line(FILE *fptr, polycap_error **error);
 void polycap_description_check_weight(size_t nelem, double wi[], polycap_error **error);
-int polycap_capil_segment(polycap_vector3 cap_coord0, polycap_vector3 cap_coord1, double cap_rad0, double cap_rad1, polycap_vector3 *photon_coord, polycap_vector3 photon_dir, polycap_vector3 *surface_norm, double *alfa, polycap_error **error);
-double polycap_refl(double e, double theta, double density, double scatf, double lin_abs_coeff, polycap_error **error);
-int polycap_capil_reflect(polycap_photon *photon, double alfa, polycap_error **error);
 void polycap_photon_scatf(polycap_photon *photon, polycap_error **error);
 
 

--- a/src/polycap-profile.c
+++ b/src/polycap-profile.c
@@ -7,7 +7,7 @@
 #include <errno.h>
 
 //===========================================
-bool polynomialfit(int obs, int degree, 
+STATIC bool polynomialfit(int obs, int degree, 
 		   double *dx, double *dy, double *store) /* n, p */
 {
   gsl_multifit_linear_workspace *ws;

--- a/src/polycap-rng.c
+++ b/src/polycap-rng.c
@@ -46,16 +46,17 @@ void polycap_rng_free(polycap_rng *rng) {
 }
 
 /* private */
-polycap_rng * polycap_rng_alloc(const polycap_rng_type * T) {
+HIDDEN polycap_rng * polycap_rng_alloc(const polycap_rng_type * T) {
 	polycap_rng *rng = calloc(1, sizeof(polycap_rng));
 	rng->_rng = _polycap_rng_alloc(T);
 	return rng;
 }
 
-void polycap_rng_set(const polycap_rng * r, unsigned long int s) {
+HIDDEN void polycap_rng_set(const polycap_rng * r, unsigned long int s) {
 	_polycap_rng_set(r, s);
 }
-double polycap_rng_uniform(const polycap_rng * r) {
+
+HIDDEN double polycap_rng_uniform(const polycap_rng * r) {
 	return _polycap_rng_uniform(r);
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I${top_srcdir}/src -I$(top_srcdir)/include -DEXAMPLE_DIR=\"$(top_srcdir)/example/\"
+AM_CPPFLAGS = -I${top_srcdir}/src -I$(top_srcdir)/include -DEXAMPLE_DIR=\"$(top_srcdir)/example/\" -DTEST_BUILD
 
 check_PROGRAMS = error profile description capil photon source
 check_SCRIPTS =
@@ -9,32 +9,32 @@ endif
 TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
 
 error_SOURCES = error.c
-error_LDADD = ../src/libpolycap.la
+error_LDADD = ../src/libpolycap-check.la
 error_CFLAGS = @OPENMP_CFLAGS@
 error_LDFLAGS = @OPENMP_CFLAGS@
 
 profile_SOURCES = profile.c
-profile_LDADD = ../src/libpolycap.la
+profile_LDADD = ../src/libpolycap-check.la
 profile_CFLAGS = @OPENMP_CFLAGS@
 profile_LDFLAGS = @OPENMP_CFLAGS@
 
 description_SOURCES = description.c
-description_LDADD = ../src/libpolycap.la
+description_LDADD = ../src/libpolycap-check.la
 description_CFLAGS = @OPENMP_CFLAGS@ @easyRNG_CFLAGS@
 description_LDFLAGS = @OPENMP_CFLAGS@
 
 capil_SOURCES = capil.c
-capil_LDADD = ../src/libpolycap.la
+capil_LDADD = ../src/libpolycap-check.la
 capil_CFLAGS = @OPENMP_CFLAGS@ @easyRNG_CFLAGS@
 capil_LDFLAGS = @OPENMP_CFLAGS@
 
 photon_SOURCES = photon.c
-photon_LDADD = ../src/libpolycap.la
+photon_LDADD = ../src/libpolycap-check.la
 photon_CFLAGS = @OPENMP_CFLAGS@ @easyRNG_CFLAGS@
 photon_LDFLAGS = @OPENMP_CFLAGS@
 
 source_SOURCES = source.c
-source_LDADD = ../src/libpolycap.la
+source_LDADD = ../src/libpolycap-check.la
 source_CFLAGS = @OPENMP_CFLAGS@ @easyRNG_CFLAGS@
 source_LDFLAGS = @OPENMP_CFLAGS@
 

--- a/tests/capil.c
+++ b/tests/capil.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
+
 void test_polycap_capil_segment() {
 	polycap_error *error = NULL;
 	int test = 0;


### PR DESCRIPTION
* Symbols that will not be used outside of the source file should be
marked as STATIC
* Symbols that will not be used outside of the library (as in not part of
the public API!), should be marked as HIDDEN

This convention will still allow these methods to be tested in unit
tests, due to a convenience library libpolycap-check.la, which will have
the STATIC and HIDDEN macros replace with an empty string.