### PR TITLE
configure.ac: restore support for older automakes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ PKG_CHECK_MODULES([easyRNG],[easyRNG >= 1.1],
 	AC_DEFINE([HAVE_EASYRNG], [], [building with easyRNG support])
 	AC_SUBST([EASYRNG_PC], "easyRNG")
 	],[
+	:
 	])
 
 AC_LANG_PUSH(C)


### PR DESCRIPTION
Should fix the syntax errors seen when running configure generated with CentOS 6' autotools.