### PR TITLE
leak_rename

### DIFF
--- a/src/polycap-private.h
+++ b/src/polycap-private.h
@@ -130,10 +130,10 @@ typedef struct _polycap_leak 	polycap_leak;
 struct _polycap_photon
   {
   polycap_description *description;
-  polycap_leak *leaks;
-  polycap_leak *recap;
-  int64_t n_leaks;
-  int64_t n_recap;
+  polycap_leak *extleak;
+  polycap_leak *intleak;
+  int64_t n_extleak;
+  int64_t n_intleak;
   polycap_vector3 start_coords;
   polycap_vector3 start_direction;
   polycap_vector3 start_electric_vector;
@@ -173,17 +173,17 @@ struct _polycap_images
   int64_t *pc_exit_nrefl;
   double *pc_exit_dtravel;
   double *exit_coord_weights;
-  int64_t i_leak;
-  double *leak_coords[3];
-  double *leak_dir[2];
-  double *leak_coord_weights;
-  int64_t *leak_n_refl;
-  int64_t i_recap;
-  double *recap_coords[3];
-  double *recap_dir[2];
-  double *recap_elecv[2];
-  double *recap_coord_weights;
-  int64_t *recap_n_refl;
+  int64_t i_extleak;
+  double *extleak_coords[3];
+  double *extleak_dir[2];
+  double *extleak_coord_weights;
+  int64_t *extleak_n_refl;
+  int64_t i_intleak;
+  double *intleak_coords[3];
+  double *intleak_dir[2];
+  double *intleak_elecv[2];
+  double *intleak_coord_weights;
+  int64_t *intleak_n_refl;
   };
 
 int polycap_photon_within_pc_boundary(double polycap_radius, polycap_vector3 photon_coord, polycap_error **error);
@@ -195,7 +195,7 @@ int polycap_capil_trace_wall(polycap_photon *photon, double *d_travel, int *capx
 char *polycap_read_input_line(FILE *fptr, polycap_error **error);
 void polycap_description_check_weight(size_t nelem, double wi[], polycap_error **error);
 void polycap_photon_scatf(polycap_photon *photon, polycap_error **error);
-void polycap_leak_free(polycap_leak *leak, int64_t n_leaks);
+void polycap_leak_free(polycap_leak *leak, int64_t n_leak);
 
 #endif
 

--- a/src/polycap-transmission-efficiencies.c
+++ b/src/polycap-transmission-efficiencies.c
@@ -504,43 +504,43 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 	if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/PC_Exit/D_Travel", efficiencies->images->pc_exit_dtravel,"[cm]", error))
 		return false;
 
-	if(efficiencies->images->i_leak > 0){
+	if(efficiencies->images->i_extleak > 0){
 		//Write leak photons data
 		//Make Leaks group
 		Leaks_id = H5Gcreate2(file, "/ExternalLeaks", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 			//write coordinates
 		//Copy coordinate data to temporary array for straightforward HDF5 writing
-		data_temp = malloc(sizeof(double)*efficiencies->images->i_leak*3);
+		data_temp = malloc(sizeof(double)*efficiencies->images->i_extleak*3);
 		if(data_temp == NULL){
 			polycap_set_error_literal(error, POLYCAP_ERROR_MEMORY, strerror(errno));
 			return false;
 		}
-		for(j=0;j<efficiencies->images->i_leak;j++){
-			data_temp[j] = efficiencies->images->leak_coords[0][j];
-			data_temp[j+efficiencies->images->i_leak] = efficiencies->images->leak_coords[1][j];
-			data_temp[j+efficiencies->images->i_leak*2] = efficiencies->images->leak_coords[2][j];
+		for(j=0;j<efficiencies->images->i_extleak;j++){
+			data_temp[j] = efficiencies->images->extleak_coords[0][j];
+			data_temp[j+efficiencies->images->i_extleak] = efficiencies->images->extleak_coords[1][j];
+			data_temp[j+efficiencies->images->i_extleak*2] = efficiencies->images->extleak_coords[2][j];
 		}
 		//Define temporary dataset dimension
 		dim[0] = 3;
-		dim[1] = efficiencies->images->i_leak;
+		dim[1] = efficiencies->images->i_extleak;
 		if (!polycap_h5_write_dataset(file, 2, dim, "/ExternalLeaks/Coordinates", data_temp,"[cm,cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
 			//write direction
 		//Copy direction data to temporary array for straightforward HDF5 writing
-		data_temp = malloc(sizeof(double)*efficiencies->images->i_leak*2);
+		data_temp = malloc(sizeof(double)*efficiencies->images->i_extleak*2);
 		if(data_temp == NULL){
 			polycap_set_error_literal(error, POLYCAP_ERROR_MEMORY, strerror(errno));
 			return false;
 		}
-		for(j=0;j<efficiencies->images->i_leak;j++){
-			data_temp[j] = efficiencies->images->leak_dir[0][j];
-			data_temp[j+efficiencies->images->i_leak] = efficiencies->images->leak_dir[1][j];
+		for(j=0;j<efficiencies->images->i_extleak;j++){
+			data_temp[j] = efficiencies->images->extleak_dir[0][j];
+			data_temp[j+efficiencies->images->i_extleak] = efficiencies->images->extleak_dir[1][j];
 		}
 		//Define temporary dataset dimension
 		dim[0] = 2;
-		dim[1] = efficiencies->images->i_leak;
+		dim[1] = efficiencies->images->i_extleak;
 		if (!polycap_h5_write_dataset(file, 2, dim, "/ExternalLeaks/Direction", data_temp,"[cm,cm]", error))
 			return false;
 		//Free data_temp
@@ -548,15 +548,15 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 			//Write leaked photon weights
 		//Define temporary dataset dimension
 		dim[1] = efficiencies->n_energies;
-		dim[0] = efficiencies->images->i_leak;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/ExternalLeaks/Weights", efficiencies->images->leak_coord_weights,"[keV,a.u.]", error))
+		dim[0] = efficiencies->images->i_extleak;
+		if (!polycap_h5_write_dataset(file, 2, dim, "/ExternalLeaks/Weights", efficiencies->images->extleak_coord_weights,"[keV,a.u.]", error))
 			return false;
 		//Save weight average as function of energy
 		data_temp = malloc(sizeof(double)*efficiencies->n_energies);
 		for(j=0; j<efficiencies->n_energies; j++){
 			data_temp[j] = 0.0;
-			for(k=0; k<efficiencies->images->i_leak; k++){
-				data_temp[j] += efficiencies->images->leak_coord_weights[k*efficiencies->n_energies+j];
+			for(k=0; k<efficiencies->images->i_extleak; k++){
+				data_temp[j] += efficiencies->images->extleak_coord_weights[k*efficiencies->n_energies+j];
 			}
 			data_temp[j] = data_temp[j] / (double)efficiencies->images->i_start;
 		}
@@ -566,14 +566,14 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Free data_temp
 		free(data_temp);
 		//Write n_reflections for each leaked photon
-		n_energies_temp = efficiencies->images->i_leak;
+		n_energies_temp = efficiencies->images->i_extleak;
 		data_temp = malloc(sizeof(double)*n_energies_temp);
 		if(data_temp == NULL){
 			polycap_set_error_literal(error, POLYCAP_ERROR_MEMORY, strerror(errno));
 			return false;
 		}
 		for(j=0; j<n_energies_temp; j++)
-			data_temp[j] = (double)efficiencies->images->leak_n_refl[j];
+			data_temp[j] = (double)efficiencies->images->extleak_n_refl[j];
 		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/ExternalLeaks/N_Reflections", data_temp,"a.u.", error))
 			return false;
 		//Free data_temp
@@ -583,76 +583,76 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 			set_exception(error);
 	}
 
-	//Write recap photons data
+	//Write intleak photons data
 	//Make Recap group
-	if(efficiencies->images->i_recap > 0){
+	if(efficiencies->images->i_intleak > 0){
 		Recap_id = H5Gcreate2(file, "/InternalLeaks", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 			//write coordinates
 		//Copy coordinate data to temporary array for straightforward HDF5 writing
-		data_temp = malloc(sizeof(double)*efficiencies->images->i_recap*3);
+		data_temp = malloc(sizeof(double)*efficiencies->images->i_intleak*3);
 		if(data_temp == NULL){
 			polycap_set_error_literal(error, POLYCAP_ERROR_MEMORY, strerror(errno));
 			return false;
 		}
-		for(j=0;j<efficiencies->images->i_recap;j++){
-			data_temp[j] = efficiencies->images->recap_coords[0][j];
-			data_temp[j+efficiencies->images->i_recap] = efficiencies->images->recap_coords[1][j];
-			data_temp[j+efficiencies->images->i_recap*2] = efficiencies->images->recap_coords[2][j];
+		for(j=0;j<efficiencies->images->i_intleak;j++){
+			data_temp[j] = efficiencies->images->intleak_coords[0][j];
+			data_temp[j+efficiencies->images->i_intleak] = efficiencies->images->intleak_coords[1][j];
+			data_temp[j+efficiencies->images->i_intleak*2] = efficiencies->images->intleak_coords[2][j];
 		}
 		//Define temporary dataset dimension
 		dim[0] = 3;
-		dim[1] = efficiencies->images->i_recap;
+		dim[1] = efficiencies->images->i_intleak;
 		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Coordinates", data_temp,"[cm,cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
 			//write direction
 		//Copy direction data to temporary array for straightforward HDF5 writing
-		data_temp = malloc(sizeof(double)*efficiencies->images->i_recap*2);
+		data_temp = malloc(sizeof(double)*efficiencies->images->i_intleak*2);
 		if(data_temp == NULL){
 			polycap_set_error_literal(error, POLYCAP_ERROR_MEMORY, strerror(errno));
 			return false;
 		}
-		for(j=0;j<efficiencies->images->i_recap;j++){
-			data_temp[j] = efficiencies->images->recap_dir[0][j];
-			data_temp[j+efficiencies->images->i_recap] = efficiencies->images->recap_dir[1][j];
+		for(j=0;j<efficiencies->images->i_intleak;j++){
+			data_temp[j] = efficiencies->images->intleak_dir[0][j];
+			data_temp[j+efficiencies->images->i_intleak] = efficiencies->images->intleak_dir[1][j];
 		}
 		//Define temporary dataset dimension
 		dim[0] = 2;
-		dim[1] = efficiencies->images->i_recap;
+		dim[1] = efficiencies->images->i_intleak;
 		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Direction", data_temp,"[cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
-		//Write recap electric vectors
-		data_temp = malloc(sizeof(double)*efficiencies->images->i_recap*2);
+		//Write intleak electric vectors
+		data_temp = malloc(sizeof(double)*efficiencies->images->i_intleak*2);
 		if(data_temp == NULL){
 			polycap_set_error_literal(error, POLYCAP_ERROR_MEMORY, strerror(errno));
 			return false;
 		}
-		for(j=0;j<efficiencies->images->i_recap;j++){
-			data_temp[j] = efficiencies->images->recap_elecv[0][j];
-			data_temp[j+efficiencies->images->i_recap] = efficiencies->images->recap_elecv[1][j];
+		for(j=0;j<efficiencies->images->i_intleak;j++){
+			data_temp[j] = efficiencies->images->intleak_elecv[0][j];
+			data_temp[j+efficiencies->images->i_intleak] = efficiencies->images->intleak_elecv[1][j];
 		}
 		//Define temporary dataset dimension
 		dim[0] = 2;
-		dim[1] = efficiencies->images->i_recap;
+		dim[1] = efficiencies->images->i_intleak;
 		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Electric_Vector", data_temp,"[cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
-		//Write recap photon weights
+		//Write intleak photon weights
 		//Define temporary dataset dimension
 		dim[1] = efficiencies->n_energies;
-		dim[0] = efficiencies->images->i_recap;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Weights", efficiencies->images->recap_coord_weights,"[keV,a.u.]", error))
+		dim[0] = efficiencies->images->i_intleak;
+		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Weights", efficiencies->images->intleak_coord_weights,"[keV,a.u.]", error))
 			return false;
 		//Save weight average as function of energy
 		data_temp = malloc(sizeof(double)*efficiencies->n_energies);
 		for(j=0; j<efficiencies->n_energies; j++){
 			data_temp[j] = 0.0;
-			for(k=0; k<efficiencies->images->i_recap; k++){
-				data_temp[j] += efficiencies->images->recap_coord_weights[k*efficiencies->n_energies+j];
+			for(k=0; k<efficiencies->images->i_intleak; k++){
+				data_temp[j] += efficiencies->images->intleak_coord_weights[k*efficiencies->n_energies+j];
 			}
 			data_temp[j] = data_temp[j] / (double)efficiencies->images->i_start;
 		}
@@ -661,15 +661,15 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 			return false;
 		//Free data_temp
 		free(data_temp);
-		//Write	n_reflections for each recap photon
-		n_energies_temp = efficiencies->images->i_recap;
+		//Write	n_reflections for each intleak photon
+		n_energies_temp = efficiencies->images->i_intleak;
 		data_temp = malloc(sizeof(double)*n_energies_temp);
 		if(data_temp == NULL){
 			polycap_set_error_literal(error, POLYCAP_ERROR_MEMORY, strerror(errno));
 			return false;
 		}
 		for(j=0; j<n_energies_temp; j++)
-			data_temp[j] = (double)efficiencies->images->recap_n_refl[j];
+			data_temp[j] = (double)efficiencies->images->intleak_n_refl[j];
 		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/InternalLeaks/N_Reflections", data_temp,"a.u.", error))
 			return false;
 		//Free data_temp
@@ -813,38 +813,38 @@ void polycap_transmission_efficiencies_free(polycap_transmission_efficiencies *e
 			free(efficiencies->images->pc_exit_dtravel);
 		if (efficiencies->images->exit_coord_weights)
 			free(efficiencies->images->exit_coord_weights);
-		if (efficiencies->images->leak_coords[0])
-			free(efficiencies->images->leak_coords[0]);
-		if (efficiencies->images->leak_coords[1])
-			free(efficiencies->images->leak_coords[1]);
-		if (efficiencies->images->leak_coords[2])
-			free(efficiencies->images->leak_coords[2]);
-		if (efficiencies->images->leak_dir[0])
-			free(efficiencies->images->leak_dir[0]);
-		if (efficiencies->images->leak_dir[1])
-			free(efficiencies->images->leak_dir[1]);
-		if (efficiencies->images->leak_coord_weights)
-			free(efficiencies->images->leak_coord_weights);
-		if (efficiencies->images->leak_n_refl)
-			free(efficiencies->images->leak_n_refl);
-		if (efficiencies->images->recap_coords[0])
-			free(efficiencies->images->recap_coords[0]);
-		if (efficiencies->images->recap_coords[1])
-			free(efficiencies->images->recap_coords[1]);
-		if (efficiencies->images->recap_coords[2])
-			free(efficiencies->images->recap_coords[2]);
-		if (efficiencies->images->recap_dir[0])
-			free(efficiencies->images->recap_dir[0]);
-		if (efficiencies->images->recap_dir[1])
-			free(efficiencies->images->recap_dir[1]);
-		if (efficiencies->images->recap_elecv[0])
-			free(efficiencies->images->recap_elecv[0]);
-		if (efficiencies->images->recap_elecv[1])
-			free(efficiencies->images->recap_elecv[1]);
-		if (efficiencies->images->recap_coord_weights)
-			free(efficiencies->images->recap_coord_weights);
-		if (efficiencies->images->recap_n_refl)
-			free(efficiencies->images->recap_n_refl);
+		if (efficiencies->images->extleak_coords[0])
+			free(efficiencies->images->extleak_coords[0]);
+		if (efficiencies->images->extleak_coords[1])
+			free(efficiencies->images->extleak_coords[1]);
+		if (efficiencies->images->extleak_coords[2])
+			free(efficiencies->images->extleak_coords[2]);
+		if (efficiencies->images->extleak_dir[0])
+			free(efficiencies->images->extleak_dir[0]);
+		if (efficiencies->images->extleak_dir[1])
+			free(efficiencies->images->extleak_dir[1]);
+		if (efficiencies->images->extleak_coord_weights)
+			free(efficiencies->images->extleak_coord_weights);
+		if (efficiencies->images->extleak_n_refl)
+			free(efficiencies->images->extleak_n_refl);
+		if (efficiencies->images->intleak_coords[0])
+			free(efficiencies->images->intleak_coords[0]);
+		if (efficiencies->images->intleak_coords[1])
+			free(efficiencies->images->intleak_coords[1]);
+		if (efficiencies->images->intleak_coords[2])
+			free(efficiencies->images->intleak_coords[2]);
+		if (efficiencies->images->intleak_dir[0])
+			free(efficiencies->images->intleak_dir[0]);
+		if (efficiencies->images->intleak_dir[1])
+			free(efficiencies->images->intleak_dir[1]);
+		if (efficiencies->images->intleak_elecv[0])
+			free(efficiencies->images->intleak_elecv[0]);
+		if (efficiencies->images->intleak_elecv[1])
+			free(efficiencies->images->intleak_elecv[1]);
+		if (efficiencies->images->intleak_coord_weights)
+			free(efficiencies->images->intleak_coord_weights);
+		if (efficiencies->images->intleak_n_refl)
+			free(efficiencies->images->intleak_n_refl);
 		free(efficiencies->images);
 	}
 	free(efficiencies);

--- a/src/polycap-transmission-efficiencies.c
+++ b/src/polycap-transmission-efficiencies.c
@@ -507,7 +507,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 	if(efficiencies->images->i_leak > 0){
 		//Write leak photons data
 		//Make Leaks group
-		Leaks_id = H5Gcreate2(file, "/Leaks", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+		Leaks_id = H5Gcreate2(file, "/ExternalLeaks", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 			//write coordinates
 		//Copy coordinate data to temporary array for straightforward HDF5 writing
 		data_temp = malloc(sizeof(double)*efficiencies->images->i_leak*3);
@@ -523,7 +523,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Define temporary dataset dimension
 		dim[0] = 3;
 		dim[1] = efficiencies->images->i_leak;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/Leaks/Coordinates", data_temp,"[cm,cm,cm]", error))
+		if (!polycap_h5_write_dataset(file, 2, dim, "/ExternalLeaks/Coordinates", data_temp,"[cm,cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -541,7 +541,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Define temporary dataset dimension
 		dim[0] = 2;
 		dim[1] = efficiencies->images->i_leak;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/Leaks/Direction", data_temp,"[cm,cm]", error))
+		if (!polycap_h5_write_dataset(file, 2, dim, "/ExternalLeaks/Direction", data_temp,"[cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -549,7 +549,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Define temporary dataset dimension
 		dim[1] = efficiencies->n_energies;
 		dim[0] = efficiencies->images->i_leak;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/Leaks/Weights", efficiencies->images->leak_coord_weights,"[keV,a.u.]", error))
+		if (!polycap_h5_write_dataset(file, 2, dim, "/ExternalLeaks/Weights", efficiencies->images->leak_coord_weights,"[keV,a.u.]", error))
 			return false;
 		//Save weight average as function of energy
 		data_temp = malloc(sizeof(double)*efficiencies->n_energies);
@@ -561,7 +561,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 			data_temp[j] = data_temp[j] / (double)efficiencies->images->i_start;
 		}
 		n_energies_temp = efficiencies->n_energies;
-		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/Leaks/Weight_Total", data_temp,"a.u.", error))
+		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/ExternalLeaks/Weight_Total", data_temp,"a.u.", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -574,7 +574,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		}
 		for(j=0; j<n_energies_temp; j++)
 			data_temp[j] = (double)efficiencies->images->leak_n_refl[j];
-		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/Leaks/N_Reflections", data_temp,"a.u.", error))
+		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/ExternalLeaks/N_Reflections", data_temp,"a.u.", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -586,7 +586,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 	//Write recap photons data
 	//Make Recap group
 	if(efficiencies->images->i_recap > 0){
-		Recap_id = H5Gcreate2(file, "/Recap", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+		Recap_id = H5Gcreate2(file, "/InternalLeaks", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
 			//write coordinates
 		//Copy coordinate data to temporary array for straightforward HDF5 writing
 		data_temp = malloc(sizeof(double)*efficiencies->images->i_recap*3);
@@ -602,7 +602,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Define temporary dataset dimension
 		dim[0] = 3;
 		dim[1] = efficiencies->images->i_recap;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/Recap/Coordinates", data_temp,"[cm,cm,cm]", error))
+		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Coordinates", data_temp,"[cm,cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -620,7 +620,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Define temporary dataset dimension
 		dim[0] = 2;
 		dim[1] = efficiencies->images->i_recap;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/Recap/Direction", data_temp,"[cm,cm]", error))
+		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Direction", data_temp,"[cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -637,7 +637,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Define temporary dataset dimension
 		dim[0] = 2;
 		dim[1] = efficiencies->images->i_recap;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/Recap/Electric_Vector", data_temp,"[cm,cm]", error))
+		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Electric_Vector", data_temp,"[cm,cm]", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -645,7 +645,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		//Define temporary dataset dimension
 		dim[1] = efficiencies->n_energies;
 		dim[0] = efficiencies->images->i_recap;
-		if (!polycap_h5_write_dataset(file, 2, dim, "/Recap/Weights", efficiencies->images->recap_coord_weights,"[keV,a.u.]", error))
+		if (!polycap_h5_write_dataset(file, 2, dim, "/InternalLeaks/Weights", efficiencies->images->recap_coord_weights,"[keV,a.u.]", error))
 			return false;
 		//Save weight average as function of energy
 		data_temp = malloc(sizeof(double)*efficiencies->n_energies);
@@ -657,7 +657,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 			data_temp[j] = data_temp[j] / (double)efficiencies->images->i_start;
 		}
 		n_energies_temp = efficiencies->n_energies;
-		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/Recap/Weight_Total", data_temp,"a.u.", error))
+		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/InternalLeaks/Weight_Total", data_temp,"a.u.", error))
 			return false;
 		//Free data_temp
 		free(data_temp);
@@ -670,7 +670,7 @@ bool polycap_transmission_efficiencies_write_hdf5(polycap_transmission_efficienc
 		}
 		for(j=0; j<n_energies_temp; j++)
 			data_temp[j] = (double)efficiencies->images->recap_n_refl[j];
-		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/Recap/N_Reflections", data_temp,"a.u.", error))
+		if (!polycap_h5_write_dataset(file, 1, &n_energies_temp, "/InternalLeaks/N_Reflections", data_temp,"a.u.", error))
 			return false;
 		//Free data_temp
 		free(data_temp);


### PR DESCRIPTION
Renaming `recap` and `leaks` variables to internal and external leak, better matching the upcoming manuscript terminology.